### PR TITLE
Fix of the build.jl

### DIFF
--- a/bin/build.jl
+++ b/bin/build.jl
@@ -6,4 +6,4 @@ out_path = length(ARGS) > 1 ? ARGS[1] : "Baysor";
 baysor_path = length(ARGS) > 2 ? ARGS[2] : dirname(@__DIR__);
 
 Base.LOAD_PATH .= baysor_path
-create_app(baysor_path, out_path; precompile_execution_file="$(baysor_path)/bin/build.jl")
+create_app(baysor_path, out_path; precompile_execution_file="$(baysor_path)/bin/precompile.jl")


### PR DESCRIPTION
Now if you'll call `build.jl `it will run endlessly because of recursion.
I fixed the path of the `precompile_execution_file` parameter