### PR TITLE
Fix issue loading prior segmentation from csv column.

### DIFF
--- a/src/cli/main.jl
+++ b/src/cli/main.jl
@@ -200,7 +200,7 @@ function load_prior_segmentation!(
         )
 
         if opts.estimate_scale_from_centers
-            opts.scale, opts.scale_std = scale, scale_std
+            opts.scale, opts.scale_std = scale, string(scale_std)
         end
 
         if (prior_seg_labels !== nothing) && plot

--- a/src/data_loading/cli_wrappers.jl
+++ b/src/data_loading/cli_wrappers.jl
@@ -220,4 +220,5 @@ function load_prior_segmentation!(
 
     df_spatial[!, :prior_segmentation] = prior_seg
 
+    return prior_seg_labels, scale, scale_std
 end


### PR DESCRIPTION
I ran into a couple issues trying to run Baysor on some Xenium using the segmentation from 10x's software as prior segmentation in Baysor, which I've fixed here.

First was assigning a number to a String field, and second was `load_prior_segmentation!` not returning what it was assumed to return.